### PR TITLE
Project output configuration

### DIFF
--- a/src/jest/project-tests.ts
+++ b/src/jest/project-tests.ts
@@ -54,12 +54,15 @@ export class ProjectTests implements ProjectTestsInit, Required<ProjectTestsInit
    *
    * @returns A promise resolved to Jest options.
    */
-  build(): Promise<InitialOptionsTsJest> {
+  async build(): Promise<InitialOptionsTsJest> {
     const swc = this.runner === 'swc';
     const options = this.#options;
+    const output = await this.project.output;
+    const { targetDir, cacheDir } = output;
     const config: InitialOptionsTsJest &
       Required<Pick<InitialOptionsTsJest, 'globals' | 'reporters' | 'transform'>> = {
       ...options,
+      cacheDirectory: path.join(cacheDir, 'jest'),
       extensionsToTreatAsEsm: options.extensionsToTreatAsEsm ?? ['.ts'],
       globals: {
         ...(options.globals || { 'ts-jest': {} }),
@@ -76,7 +79,7 @@ export class ProjectTests implements ProjectTestsInit, Required<ProjectTestsInit
               'jest-junit',
               {
                 suiteName: 'All Tests',
-                outputDirectory: path.join(this.#project.targetDir, 'test-results'),
+                outputDirectory: path.join(targetDir, 'test-results'),
                 classNameTemplate: '{classname}: {title}',
                 titleTemplate: '{classname}: {title}',
                 ancestorSeparator: ' › ',
@@ -144,8 +147,7 @@ export class ProjectTests implements ProjectTestsInit, Required<ProjectTestsInit
         `!${srcDir}/spec/**`,
         '!**/node_modules/**',
       ];
-      config.coverageDirectory
-        = options.coverageDirectory ?? path.join(this.#project.targetDir, 'coverage');
+      config.coverageDirectory = options.coverageDirectory ?? path.join(targetDir, 'coverage');
       config.coverageThreshold = options.coverageThreshold ?? {
         global: {
           statements: 100,
@@ -156,7 +158,7 @@ export class ProjectTests implements ProjectTestsInit, Required<ProjectTestsInit
       };
     }
 
-    return Promise.resolve(config);
+    return config;
   }
 
 }

--- a/src/jest/project-tests.ts
+++ b/src/jest/project-tests.ts
@@ -76,7 +76,7 @@ export class ProjectTests implements ProjectTestsInit, Required<ProjectTestsInit
               'jest-junit',
               {
                 suiteName: 'All Tests',
-                outputDirectory: path.join(this.#project.buildDir, 'test-results'),
+                outputDirectory: path.join(this.#project.targetDir, 'test-results'),
                 classNameTemplate: '{classname}: {title}',
                 titleTemplate: '{classname}: {title}',
                 ancestorSeparator: ' › ',
@@ -145,7 +145,7 @@ export class ProjectTests implements ProjectTestsInit, Required<ProjectTestsInit
         '!**/node_modules/**',
       ];
       config.coverageDirectory
-        = options.coverageDirectory ?? path.join(this.#project.buildDir, 'coverage');
+        = options.coverageDirectory ?? path.join(this.#project.targetDir, 'coverage');
       config.coverageThreshold = options.coverageThreshold ?? {
         global: {
           statements: 100,

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -6,4 +6,5 @@ export * from './package/mod.js';
 export * from './project-config.js';
 export * from './project-entry.js';
 export * from './project-export.js';
+export * from './project-output.js';
 export * from './typescript/mod.js';

--- a/src/project-config.ts
+++ b/src/project-config.ts
@@ -13,7 +13,7 @@ export class ProjectConfig implements ProjectInit, Required<ProjectInit> {
   readonly #rootDir: string;
   readonly #sourceDir: string;
   readonly #distDir: string;
-  readonly #buildDir: string;
+  readonly #targetDir: string;
   readonly #typescript: ProjectTypescript;
   #packageJson?: PackageJson;
   #exports?: Promise<ReadonlyMap<string, ProjectExport>>;
@@ -29,14 +29,14 @@ export class ProjectConfig implements ProjectInit, Required<ProjectInit> {
       rootDir = process.cwd(),
       sourceDir = 'src',
       distDir = 'dist',
-      buildDir = 'target',
+      targetDir = 'target',
       typescript,
     } = init;
 
     this.#rootDir = path.resolve(rootDir);
     this.#sourceDir = path.resolve(this.#rootDir, sourceDir);
     this.#distDir = path.resolve(this.#rootDir, distDir);
-    this.#buildDir = path.resolve(this.#rootDir, buildDir);
+    this.#targetDir = path.resolve(this.#rootDir, targetDir);
     this.#typescript = new ProjectTypescript(this, typescript);
   }
 
@@ -57,8 +57,8 @@ export class ProjectConfig implements ProjectInit, Required<ProjectInit> {
     return this.#sourceDir;
   }
 
-  get buildDir(): string {
-    return this.#buildDir;
+  get targetDir(): string {
+    return this.#targetDir;
   }
 
   get distDir(): string {
@@ -160,11 +160,13 @@ export interface ProjectInit {
   readonly distDir?: string | undefined;
 
   /**
-   * Temporal build directory relative to {@link rootDir project root}.
+   * Directory containing build targets relative to {@link rootDir project root}.
+   *
+   * Unlike {@link distDir}, this one is not supposed to be published at NPM.
    *
    * @defaultValue `target`.
    */
-  readonly buildDir?: string | undefined;
+  readonly targetDir?: string | undefined;
 
   /**
    * TypeScript initialization options.

--- a/src/project-entry.ts
+++ b/src/project-entry.ts
@@ -1,22 +1,23 @@
 import path from 'node:path';
 import { ProjectConfig } from './project-config.js';
 import { ProjectExport } from './project-export.js';
+import { ProjectOutput } from './project-output.js';
 
 /**
  * Abstract project entry configuration.
  */
 export abstract class ProjectEntry {
 
-  readonly #project: ProjectConfig;
+  readonly #output: ProjectOutput;
   #name?: string;
 
   /**
    * Constructs project entry configuration for the `project`.
    *
-   * @param project - Target project configuration.
+   * @param output - Target project output configuration.
    */
-  constructor(project: ProjectConfig) {
-    this.#project = project;
+  constructor(output: ProjectOutput) {
+    this.#output = output;
   }
 
   /**
@@ -30,13 +31,20 @@ export abstract class ProjectEntry {
    * Target project configuration.
    */
   get project(): ProjectConfig {
-    return this.#project;
+    return this.output.project;
+  }
+
+  /**
+   * Target project output configuration.
+   */
+  get output(): ProjectOutput {
+    return this.#output;
   }
 
   /**
    * Short entry name.
    *
-   * By defaults, equals to {@link distFile distribution file} path relative to {@link ProjectConfig.distDir
+   * By defaults, equals to {@link distFile distribution file} path relative to {@link ProjectOutput#distDir
    * distribution directory} without an extension.
    */
   get name(): string {
@@ -44,8 +52,8 @@ export abstract class ProjectEntry {
       const distFile = this.distFile;
       const fileExt = path.extname(distFile);
       const fileName = path.relative(
-        this.#project.distDir,
-        path.resolve(this.#project.distDir, distFile),
+        this.output.distDir,
+        path.resolve(this.output.distDir, distFile),
       );
 
       this.#name = fileExt ? fileName.slice(0, -fileExt.length) : fileExt;
@@ -55,12 +63,12 @@ export abstract class ProjectEntry {
   }
 
   /**
-   * Path to source file to transpile during the build relative to {@link ProjectConfig.sourceDir sources directory}.
+   * Path to source file to transpile during the build relative to {@link ProjectConfig#sourceDir sources directory}.
    */
   abstract get sourceFile(): string;
 
   /**
-   * Path to distribution file relative to {@link ProjectConfig.distDir distribution directory}.
+   * Path to distribution file relative to {@link ProjectOutput#distDir distribution directory}.
    *
    * This is typically a file listed in `package.json` exports section and generated from
    * {@link sourceFile source file}.

--- a/src/project-export.ts
+++ b/src/project-export.ts
@@ -4,6 +4,7 @@ import path from 'node:path';
 import { PackageJson } from './package/package-json.js';
 import { ProjectConfig } from './project-config.js';
 import { ProjectEntry } from './project-entry.js';
+import { ProjectOutput } from './project-output.js';
 
 /**
  * Project entry corresponding to {@link PackageJson.EntryPoint package export}.
@@ -36,7 +37,8 @@ export class ProjectExport extends ProjectEntry {
       return;
     }
 
-    const distFile = path.relative(project.distDir, distFilePath);
+    const output = await project.output;
+    const distFile = path.relative(output.distDir, distFilePath);
 
     const { sourceFile = await ProjectExport$detectSourceFile(project, distFile) } = init;
 
@@ -44,7 +46,7 @@ export class ProjectExport extends ProjectEntry {
       return;
     }
 
-    return new ProjectExport({ project, entryPoint, sourceFile, distFile });
+    return new ProjectExport({ output, entryPoint, sourceFile, distFile });
   }
 
   readonly #entryPoint: PackageJson.EntryPoint;
@@ -57,14 +59,14 @@ export class ProjectExport extends ProjectEntry {
    * @param init - Export initialization options.
    */
   protected constructor(
-    init: Required<ProjectExportInit> & {
-      readonly project: ProjectConfig;
+    init: Omit<Required<ProjectExportInit>, 'project'> & {
+      readonly output: ProjectOutput;
       readonly distFile: string;
     },
   ) {
-    const { project, entryPoint, sourceFile, distFile } = init;
+    const { output, entryPoint, sourceFile, distFile } = init;
 
-    super(project);
+    super(output);
 
     this.#entryPoint = entryPoint;
     this.#sourceFile = sourceFile;

--- a/src/project-output.ts
+++ b/src/project-output.ts
@@ -1,0 +1,226 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import os from 'node:os';
+import { ProjectConfig } from './project-config.js';
+
+/**
+ * Project output configuration.
+ */
+export class ProjectOutput implements ProjectOutputInit, Required<ProjectOutputInit> {
+
+  /**
+   * Creates project output configuration.
+   *
+   * First, tries to load configuration from `.project-output.json` file within {@link ProjectOutputInit#targetDir build
+   * target directory} if the file exists.
+   *
+   * If output configuration can not be loaded or differs from initialization otions, stores new configuration to the
+   * file.
+   *
+   * @param init - Output initialization options.
+   *
+   * @returns Promise resolved to project output configuration.
+   */
+  static async create(
+    project: ProjectConfig,
+    init: ProjectOutputInit = {},
+  ): Promise<ProjectOutput> {
+    const { rootDir } = project;
+    let { distDir = 'dist', targetDir = 'target' } = init;
+
+    distDir = path.resolve(rootDir, distDir);
+    targetDir = path.resolve(rootDir, targetDir);
+
+    await fs.mkdir(targetDir, { recursive: true });
+
+    const configFile = ProjectOutput.#configFile(targetDir);
+    const oldConfig = await ProjectOutput.#load(configFile);
+
+    let { cacheDir } = init;
+
+    if (!cacheDir) {
+      if (oldConfig) {
+        cacheDir = oldConfig.cacheDir;
+      } else {
+        cacheDir = await fs.mkdtemp(path.join(os.tmpdir(), 'run-z.project-cache.'));
+      }
+    }
+
+    const dirSet = new Set(oldConfig?.dirs);
+
+    dirSet.add(distDir);
+    dirSet.add(targetDir);
+    dirSet.add(cacheDir);
+
+    const dirs = [...dirSet];
+
+    const output = new ProjectOutput(project, {
+      distDir,
+      targetDir,
+      cacheDir,
+      dirs,
+    });
+
+    if (!oldConfig || distDir !== oldConfig.distDir || cacheDir !== oldConfig.cacheDir) {
+      await output.save();
+    }
+
+    return output;
+  }
+
+  static #configFile(targetDir: string): string {
+    return path.join(targetDir, '.project-output.json');
+  }
+
+  static async #load(configFile: string): Promise<ProjectOutputJson | undefined> {
+    try {
+      return JSON.parse(await fs.readFile(configFile, 'utf-8')) as ProjectOutputJson;
+    } catch {
+      // No config file yet.
+    }
+
+    return;
+  }
+
+  readonly #project: ProjectConfig;
+  readonly #distDir: string;
+  readonly #targetDir: string;
+  readonly #cacheDir: string;
+  #dirs: readonly string[];
+  #isSaved = true;
+
+  private constructor(
+    project: ProjectConfig,
+    {
+      distDir,
+      targetDir,
+      cacheDir,
+      dirs,
+    }: Required<ProjectOutputInit> & { dirs: readonly string[] },
+  ) {
+    this.#project = project;
+    this.#distDir = distDir;
+    this.#targetDir = targetDir;
+    this.#cacheDir = cacheDir;
+    this.#dirs = dirs;
+  }
+
+  /**
+   * Parent project configuration.
+   */
+  get project(): ProjectConfig {
+    return this.#project;
+  }
+
+  /**
+   * Distributable files` directory.
+   */
+  get distDir(): string {
+    return this.#distDir;
+  }
+
+  /**
+   * Directory containing build targets.
+   *
+   * Unlike {@link distDir}, this one is not supposed to be published at NPM.
+   */
+  get targetDir(): string {
+    return this.#targetDir;
+  }
+
+  /**
+   * Cache directory.
+   */
+  get cacheDir(): string {
+    return this.#cacheDir;
+  }
+
+  /**
+   * List of all output directories created by project build.
+   */
+  get dirs(): readonly string[] {
+    return this.#dirs;
+  }
+
+  /**
+   * Whether this configuration is saved already.
+   *
+   * `true` initially.
+   *
+   * Becomes `false` when output directories {@link ProjectOutput#clean deleted}.
+   *
+   * Becomes `true` again once configuration {@link ProjectOutput#save saved}.
+   */
+  get isSaved(): boolean {
+    return this.#isSaved;
+  }
+
+  /**
+   * Saves this project output configuration.
+   *
+   * Creates {@link targetDir build target directory} and saves output configuration to `.project-output.json` file
+   * within it.
+   */
+  async save(): Promise<void> {
+    await fs.mkdir(this.targetDir, { recursive: true });
+
+    const output: ProjectOutputJson = {
+      distDir: this.distDir,
+      cacheDir: this.cacheDir,
+      dirs: this.dirs,
+    };
+
+    await fs.writeFile(ProjectOutput.#configFile(this.targetDir), [
+      JSON.stringify(output, null, 2),
+      os.EOL,
+    ]);
+
+    this.#isSaved = true;
+  }
+
+  /**
+   * Clears and deletes all {@link ProjectOutput#dirs output directories}.
+   *
+   * Project output configuration becomes {@link ProjectOutput#isSaved unsaved} after this operation.
+   */
+  async clean(): Promise<void> {
+    await Promise.all(
+      this.dirs.map(async dir => await fs.rm(dir, { force: true, recursive: true })),
+    );
+    this.#dirs = [this.#distDir, this.#targetDir, this.#cacheDir];
+    this.#isSaved = false;
+  }
+
+}
+
+/**
+ * Project output initialization options.
+ */
+export interface ProjectOutputInit {
+  /**
+   * Distributable files` directory relative to {@link rootDir project root}.
+   *
+   * @defaultValue `dist`
+   */
+  readonly distDir?: string | undefined;
+
+  /**
+   * Directory containing build targets relative to {@link rootDir project root}.
+   *
+   * Unlike {@link distDir}, this one is not supposed to be published at NPM.
+   *
+   * @defaultValue `target`.
+   */
+  readonly targetDir?: string | undefined;
+
+  /**
+   * Cache directory relative to {@link targetDir build target directory}.
+   *
+   * @defaultValue Temporary directory.
+   */
+  readonly cacheDir?: string | undefined;
+}
+
+interface ProjectOutputJson extends Required<Omit<ProjectOutputInit, 'targetDir'>> {
+  readonly dirs: readonly string[];
+}

--- a/src/rollup/project-rollup.ts
+++ b/src/rollup/project-rollup.ts
@@ -47,7 +47,7 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
    * @returns A promise resolved to Rollup options.
    */
   async build(): Promise<RollupOptions> {
-    const { sourceDir, distDir, buildDir } = this.#project;
+    const { sourceDir, distDir, targetDir } = this.#project;
     const entries = await this.#project.entries;
     const mainEntry = await this.#project.mainEntry;
     const chunksByDir: [string, string][] = [...entries].map(([name, entry]) => {
@@ -67,7 +67,7 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
           typescript,
           tsconfig,
           tsconfigOverride: compilerOptions,
-          cacheRoot: path.join(buildDir, '.rts2_cache'),
+          cacheRoot: path.join(targetDir, '.rts2_cache'),
         }),
         sourcemaps(),
       ],
@@ -159,7 +159,7 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
           slashIdx = id.indexOf('/', slashIdx + 1);
         }
         if (slashIdx > 0) {
-          id = id.substr(0, slashIdx);
+          id = id.slice(0, slashIdx);
         }
       }
 

--- a/src/rollup/project-rollup.ts
+++ b/src/rollup/project-rollup.ts
@@ -47,7 +47,9 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
    * @returns A promise resolved to Rollup options.
    */
   async build(): Promise<RollupOptions> {
-    const { sourceDir, distDir, targetDir } = this.#project;
+    const { sourceDir } = this.#project;
+    const output = await this.#project.output;
+    const { distDir, cacheDir } = output;
     const entries = await this.#project.entries;
     const mainEntry = await this.#project.mainEntry;
     const chunksByDir: [string, string][] = [...entries].map(([name, entry]) => {
@@ -67,7 +69,7 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
           typescript,
           tsconfig,
           tsconfigOverride: compilerOptions,
-          cacheRoot: path.join(targetDir, '.rts2_cache'),
+          cacheRoot: path.join(cacheDir, 'rts2'),
         }),
         sourcemaps(),
       ],
@@ -100,11 +102,11 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
               declarationMap: true,
             },
             lib: true,
-            file: this.#dtsName(mainEntry),
+            file: this.#dtsName(distDir, mainEntry),
             entries: Object.fromEntries(
               [...entries]
                 .filter(item => item[1] !== mainEntry)
-                .map(([name, entry]) => [name, { file: this.#dtsName(entry) }]),
+                .map(([name, entry]) => [name, { file: this.#dtsName(distDir, entry) }]),
             ),
           }),
         ],
@@ -112,7 +114,7 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
     };
   }
 
-  #dtsName(entry: ProjectEntry): string {
+  #dtsName(distDir: string, entry: ProjectEntry): string {
     const projectExport = entry.toExport();
 
     if (projectExport) {
@@ -120,7 +122,7 @@ export class ProjectRollup implements ProjectRollupInit, Required<ProjectRollupI
       const types = projectExport.withConditions('types');
 
       if (types) {
-        return path.relative(this.#project.distDir, types);
+        return path.relative(distDir, types);
       }
     }
 


### PR DESCRIPTION
- Rename `buildDir` to `targetDir`
- Introduce project output configuration
